### PR TITLE
Handle hostname

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 use std::str::FromStr;
-use std::net::{AddrParseError, IpAddr, SocketAddr};
+use hyper::Url;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Stats {
@@ -35,59 +35,38 @@ impl Stats {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Server {
-    addr: SocketAddr,
-    secured: bool,
+    url: Url,
     hc_failure: usize,
     stats: Stats,
 }
 
 impl Server {
-    pub fn new(addr: SocketAddr, secured: bool) -> Server {
+    pub fn new(url: Url) -> Server {
         Server {
-            addr: addr,
-            secured: secured,
+            url: url,
             hc_failure: 0,
             stats: Stats::new(),
         }
     }
 
-    pub fn ip(&self) -> IpAddr {
-        self.addr.ip()
-    }
-
-    pub fn port(&self) -> u16 {
-        self.addr.port()
+    pub fn url(&self) -> Url {
+        self.url.clone()
     }
 
     pub fn stats_mut(&mut self) -> &mut Stats {
         &mut self.stats
     }
-
-    pub fn addr(&self) -> &SocketAddr {
-        &self.addr
-    }
-
-    pub fn secured(&self) -> bool {
-        self.secured
-    }
-
-    pub fn protocol(&self) -> &str {
-        if self.secured { "https" } else { "http" }
-    }
 }
 
 impl FromStr for Server {
-    type Err = AddrParseError;
+    type Err = ::hyper::error::ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (secured, to_parse) = if s.starts_with("https://") {
-            (true, &s[8..])
-        } else if s.starts_with("http://") {
-            (false, &s[7..])
+        let url: Url = if s.starts_with("http") {
+            try!(s.parse())
         } else {
-            (false, s)
+            try!(format!("http://{}", s).parse())
         };
-
-        FromStr::from_str(to_parse).map(|addr| Server::new(addr, secured))
+        Ok(Server::new(url))
     }
 }
 
@@ -130,8 +109,7 @@ impl Pool {
     /// Add a new server to the pool
     ///
     /// Currently, it is possible to add the same server more then once
-    pub fn add(&self, backend: SocketAddr) {
-        let server = Server::new(backend, false);
+    pub fn add(&self, server: Server) {
         self.inner.write().expect("Lock is poisoned").add(server)
     }
 
@@ -195,24 +173,18 @@ pub mod inner {
         use super::Pool;
         use super::Server;
         use std::str::FromStr;
-        use std::net::{IpAddr, Ipv4Addr};
+        use hyper::Url;
 
         #[test]
         fn test_from_str() {
             let backend1: Server = FromStr::from_str("http://127.0.0.1:6000").unwrap();
-            assert_eq!(backend1.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
-            assert_eq!(backend1.port(), 6000);
-            assert_eq!(backend1.secured, false);
+            assert_eq!(backend1.url(), Url::parse("http://127.0.0.1:6000").unwrap());
 
             let backend2: Server = FromStr::from_str("https://10.10.10.10:1010").unwrap();
-            assert_eq!(backend2.ip(), IpAddr::V4(Ipv4Addr::new(10, 10, 10, 10)));
-            assert_eq!(backend2.port(), 1010);
-            assert_eq!(backend2.secured, true);
+            assert_eq!(backend2.url(), Url::parse("https://10.10.10.10:1010").unwrap());
 
             let backend3: Server = FromStr::from_str("8.8.8.8:6543").unwrap();
-            assert_eq!(backend3.ip(), IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
-            assert_eq!(backend3.port(), 6543);
-            assert_eq!(backend3.secured, false);
+            assert_eq!(backend3.url(), Url::parse("http://8.8.8.8:6543").unwrap());
         }
 
         #[test]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -36,6 +36,7 @@ impl Stats {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Server {
     url: Url,
+    map_host: bool,
     hc_failure: usize,
     stats: Stats,
 }
@@ -44,6 +45,7 @@ impl Server {
     pub fn new(url: Url) -> Server {
         Server {
             url: url,
+            map_host: false,
             hc_failure: 0,
             stats: Stats::new(),
         }
@@ -55,6 +57,19 @@ impl Server {
 
     pub fn stats_mut(&mut self) -> &mut Stats {
         &mut self.stats
+    }
+
+    pub fn map_host(&self) -> bool {
+        self.map_host
+    }
+
+    pub fn with_map_host(self, map_host: bool) -> Self {
+        Server {
+            url: self.url,
+            map_host: map_host,
+            hc_failure: self.hc_failure,
+            stats: self.stats,
+        }
     }
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -14,6 +14,7 @@ use hyper::client::Service;
 use hyper::header;
 use hyper::server::{self, Http};
 use hyper_tls::HttpsConnector;
+use hyper::Url;
 
 use pool::Pool;
 
@@ -99,6 +100,7 @@ pub fn filter_frontend_request_headers(headers: &Headers) -> Headers {
     let _ = h.remove::<ProxyAuthorization>();
     let _ = h.remove::<Trailer>();
     let _ = h.remove::<header::Upgrade>();
+    let _ = h.remove::<header::Host>();
 
     h
 }
@@ -107,17 +109,23 @@ pub fn filter_frontend_request_headers(headers: &Headers) -> Headers {
 ///
 /// The primary purpose of this function is to add and remove headers as required by an
 /// intermediary conforming to the HTTP spec.
-fn map_request(req: server::Request, url: &str) -> client::Request {
-    let mut r = client::Request::new(req.method().clone(), url.parse().unwrap());
-
+fn map_request(req: server::Request, url: Url) -> client::Request {
     let via = create_via_header(
         req.headers().get::<Via>(),
         req.version());
 
     let mut headers = filter_frontend_request_headers(req.headers());
     headers.set(via);
-    r.headers_mut().extend(headers.iter());
 
+    // add host header related to backend
+    let host = url.host_str().unwrap().to_string();
+    let port = url.port_or_known_default();
+    headers.set(
+        header::Host::new(host, port)
+    );
+
+    let mut r = client::Request::new(req.method().clone(), url);
+    r.headers_mut().extend(headers.iter());
     r.set_body(req.body());
     r
 }
@@ -160,10 +168,11 @@ impl Service for Proxy {
 
     fn call(&self, req: server::Request) -> Self::Future {
         let server = self.pool.get().expect("Failed to get server from pool");
-        let url = format!("{}://{}{}", server.protocol(), server.addr(), req.path());
+        let url = server.url().join(req.path()).unwrap();
+
         debug!("Preparing backend request to {:?}", url);
 
-        let client_req = map_request(req, &url);
+        let client_req = map_request(req, url);
 
         let backend = self.client.call(client_req).and_then(|res| {
             debug!("Response: {}", res.status());
@@ -285,7 +294,8 @@ mod tests {
 
         assert_eq!(false, given.has::<TE>());
         assert_eq!(false, given.has::<header::TransferEncoding>());
-        assert_eq!(true, given.has::<header::Host>());
+        // the Host from the frontend is removed to be replaced by the host for the backend
+        assert_eq!(false, given.has::<header::Host>());
         assert_eq!(false, given.has::<header::Connection>());
         assert_eq!(false, given.has::<Foo>());
         assert_eq!(false, given.has::<KeepAlive>());

--- a/src/weldr.rs
+++ b/src/weldr.rs
@@ -18,6 +18,9 @@ fn main() {
 
     let backend = env::args().nth(2).unwrap_or("127.0.0.1:12345".to_string());
     let backend = backend.parse::<Server>().unwrap();
+    let map_host = env::args().nth(4).unwrap_or("false".to_string());
+    let map_host: bool = map_host.parse().unwrap();
+    let backend = backend.with_map_host(map_host);
     let pool = Pool::with_servers(vec![backend]);
 
     let admin_ip = env::args().nth(3).unwrap_or("127.0.0.1:8687".to_string());

--- a/tests/test-proxy.rs
+++ b/tests/test-proxy.rs
@@ -16,7 +16,7 @@ use hyper::{Get, Post, StatusCode};
 use hyper::server::{Http, Service, Request, Response};
 use hyper::header::{ContentLength, TransferEncoding};
 
-use weldr::pool::Pool;
+use weldr::pool::{Pool, Server};
 
 #[derive(Clone, Copy)]
 struct Origin;
@@ -85,9 +85,10 @@ fn with_server<R> (req: R) where R: Fn(String)
     });
 
     let origin = rx.recv().unwrap();
-    pool.add(origin);
+    let origin_str = format!("http://127.0.0.1:{}", origin.port());
+    pool.add(origin_str.parse::<Server>().unwrap());
 
-    req(format!("http://127.0.0.1:{}", origin.port()));
+    req(origin_str);
     req(format!("http://{}:{}", proxy_addr.ip(), proxy_addr.port()));
 }
 


### PR DESCRIPTION
to be rebased once https://github.com/hjr3/weldr/pull/77 is merged.

This PR adds the possibility to use hostnames as backends.
For example:

```
cargo run --bin weldr 127.0.0.1:9001 https://wiki-growth.herokuapp.com/ 127.0.0.1:9002
```
serves [https://wiki-growth.herokuapp.com/](https://wiki-growth.herokuapp.com/) on [http://127.0.0.1:9001](http://127.0.0.1:9001)

```
cargo run --bin weldr 127.0.0.1:9001 https://github.com/ 127.0.0.1:9002
```
serves github on [http://127.0.0.1:9001](http://127.0.0.1:9001)

To completely support github, we still have to translate cookies.
The response header:
```
Set-Cookie:logged_in=no; domain=.github.com; path=/; expires=Wed, 25 Feb 2037 13:48:23 -0000; secure; HttpOnly
```
must be translated for the proxy host name / secure or not.

And all cookie request headers must also be translated.
I propose to add an issue for that and address this in another PR.