### PR TITLE
Remove unused macro import to eliminate the warning.

### DIFF
--- a/src/test-server.rs
+++ b/src/test-server.rs
@@ -1,6 +1,6 @@
 #[macro_use] extern crate rustful;
 
-#[macro_use] extern crate log;
+extern crate log;
 extern crate env_logger;
 
 use std::env;


### PR DESCRIPTION
```
warning: unused `#[macro_use]` import
 --> src/test-server.rs:3:1
  |
3 | #[macro_use] extern crate log;
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default
```