### PR TITLE
Health check improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ See [benchmark/](./benchmark) for details on setting up real world benchmarks.
 ## High Level Roadmap
 
    * Initial [0.1.0](https://github.com/hjr3/weldr/releases/tag/0.1.0) release.
-   * Currently working on a [0.2.0](https://github.com/hjr3/weldr/milestone/2) release.
+   * Currently working on a [0.2.0](https://github.com/hjr3/weldr/milestone/2) release. [Want to help?](https://github.com/hjr3/weldr/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22%20)
+
+## Design
+
+Weldr does not use any threads. The process that is started is the manager process. That process will spawn worker processes to handle the requests. The manager process will listen for API requests and perform periodic health checks on the backend servers in the pool. Changes to the pool, caused by API requests or health checks, are sent to all the workers.
+
+### Health Checks
+
+Weldr uses _active_ health checks. As long as the health check passes, the pool will keep the server active and send it requests. A health checks is run, by default, every 30 seconds using [tokio-timer](https://crates.io/crates/tokio-timer). The health check makes a request to, by default, `/` and expects a `2xx` HTTP response code. Each server is assumed active when added to the pool. If a server fails the check, by default, 3 consecutive times, the manager will mark that server as down and then send a message to the workers to mark that same server as down. If a server marked as down later returns a `2xx` HTTP response code, by default, 2 consecutive times, it will be marked as active again.
 
 ## Proposed Management API Design
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,26 +1,36 @@
+#[derive(Default)]
 pub struct Config {
-    pub health: Health,
+    pub health_check: HealthCheck,
 }
 
-impl Config {
-    pub fn new(timeout: u64, uri: String) -> Config {
-        Config {
-            health: Health {
-                timeout: timeout,
-                uri: uri,
-            }
+pub struct HealthCheck {
+    /// The time (in seconds) between two consecutive health checks
+    pub interval: u64,
+
+    /// The URI path to health check
+    pub uri_path: String,
+
+    /// The number of consecutive health check failures to mark an active server as down
+    pub failures: u64,
+
+    /// The number of consecutive health check passes to mark a down server as active
+    pub passes: u64,
+}
+
+impl Default for HealthCheck {
+    fn default() -> HealthCheck {
+        HealthCheck {
+            interval: 10,
+            uri_path: "/".to_string(),
+            failures: 3,
+            passes: 2,
         }
     }
 }
 
-pub struct Health {
-    pub timeout: u64,
-    pub uri: String,
-}
-
 #[test]
 fn test_config() {
-    let conf = Config::new(10, "/heart_beat".to_string());
-    assert_eq!(10, conf.health.timeout);
-    assert_eq!("/heart_beat", conf.health.uri);
+    let conf = Config::default();
+    assert_eq!(10, conf.health_check.interval);
+    assert_eq!("/", conf.health_check.uri_path);
 }

--- a/src/mgmt/api.rs
+++ b/src/mgmt/api.rs
@@ -58,7 +58,8 @@ fn index() -> Response {
 }
 
 fn all_servers_reponse(pool: &Pool) -> Response {
-    let all_servers = pool.all();
+    let backends = pool.all();
+    let all_servers: Vec<Server> = backends.iter().map(|backend| backend.server()).collect();
     let servers: Vec<PoolServer> = all_servers.into_iter().map(|server| {
         let delete_href = format!("/servers/{}", server.url());
         PoolServer {

--- a/src/mgmt/health.rs
+++ b/src/mgmt/health.rs
@@ -1,48 +1,124 @@
 use std::str::FromStr;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::collections::HashMap;
 
 use futures::Future;
 use tokio_core::reactor::Handle;
 use hyper::{Client, Uri};
 use hyper_tls::HttpsConnector;
 
-use pool::Pool;
+use pool::{Pool, Backend};
 use config::Config;
+use mgmt::Manager;
 
-pub fn run(pool: Pool, handle: &Handle, conf: &Config) {
+#[derive(Clone, Debug)]
+pub struct BackendHealth {
+    inner: Rc<RefCell<Inner>>,
+}
+
+impl BackendHealth {
+    pub fn new() -> BackendHealth {
+        BackendHealth {
+            inner: Rc::new(RefCell::new(Inner {
+                pending_active: HashMap::new(),
+                pending_down: HashMap::new(),
+            }))
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    pending_active: HashMap<Backend, u64>,
+    pending_down: HashMap<Backend, u64>,
+}
+
+pub fn run(pool: Pool, handle: &Handle, conf: &Config, manager: Manager, health: BackendHealth) {
     let client = Client::configure()
         .connector(HttpsConnector::new(4, &handle))
         .build(&handle);
 
-    let servers = pool.all();
-    for server in servers {
-        let url = format!("{}{}", server.url(), &conf.health.uri);
+    let backends = pool.all();
+    let handle1 = handle.clone();
+    for backend in backends {
+        let manager = manager.clone();
+        let handle1 = handle1.clone();
+        let server = backend.server();
+        let health = health.clone();
+        let url = format!("{}{}", server.url(), &conf.health_check.uri_path);
         let url = match Uri::from_str(&url) {
             Ok(url) => url,
             Err(e) => {
                 error!("Invalid health check url: {:?}",e);
+                if backend.is_active() {
+                    let ref mut pending_down = health.inner.borrow_mut().pending_down;
+                    let failures = pending_down.entry(backend.clone()).or_insert(0);
+                    *failures += 1;
+
+                    if *failures >= conf.health_check.failures {
+                        info!("Disabling {:?} in pool", backend);
+                        backend.mark_down();
+                        let uri = backend.server().url();
+                        manager.publish_server_state_down(&uri, handle.clone());
+                    }
+                }
                 continue;
             }
         };
+
+        let allowed_failures = conf.health_check.failures;
         debug!("Health check {:?}", url);
+        let req = client.get(url).then(move |res| {
+            match res {
+                Ok(res) => {
+                    debug!("Response: {}", res.status());
+                    debug!("Headers: \n{}", res.headers());
 
-        let pool1 = pool.clone();
-        let pool2 = pool.clone();
-        let server1 = server.clone();
-        let server2 = server.clone();
-        let req = client.get(url).and_then(move |res| {
-            debug!("Response: {}", res.status());
-            debug!("Headers: \n{}", res.headers());
+                    if res.status().is_success() {
+                        if backend.is_down() {
+                            let ref mut pending_down = health.inner.borrow_mut().pending_down;
+                            let failures = pending_down.entry(backend.clone()).or_insert(0);
+                            *failures += 1;
 
-            if ! res.status().is_success() {
-                info!("Removing {:?} from pool", server1);
-                pool1.remove(&server1);
+                            if *failures >= allowed_failures {
+                                info!("Enabling {:?} in pool", backend);
+                                backend.mark_active();
+                                let uri = backend.server().url();
+                                manager.publish_server_state_active(&uri, handle1.clone());
+                            }
+                        }
+                    } else {
+                        if backend.is_active() {
+                            let ref mut pending_down = health.inner.borrow_mut().pending_down;
+                            let failures = pending_down.entry(backend.clone()).or_insert(0);
+                            *failures += 1;
+
+                            if *failures >= allowed_failures {
+                                info!("Disabling {:?} in pool", backend);
+                                backend.mark_down();
+                                let uri = backend.server().url();
+                                manager.publish_server_state_down(&uri, handle1.clone());
+                            }
+                        }
+                    }
+                    ::futures::finished(())
+                }
+                Err(e) => {
+                    error!("Error connecting to backend: {:?}", e);
+                    let ref mut pending_down = health.inner.borrow_mut().pending_down;
+                    let failures = pending_down.entry(backend.clone()).or_insert(0);
+                    *failures += 1;
+
+                    if *failures >= allowed_failures {
+                        info!("Disabling {:?} in pool", backend);
+                        backend.mark_down();
+                        let uri = backend.server().url();
+                        manager.publish_server_state_down(&uri, handle1.clone());
+                    }
+                    ::futures::finished(())
+                }
             }
-
-            ::futures::finished(())
-        }).map_err(move |e| {
-            error!("Error connecting to backend: {:?}", e);
-            info!("Removing {:?} from pool", server2);
-            pool2.remove(&server2);
         });
 
         handle.spawn(req);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -14,6 +14,7 @@ use stats::Stats;
 /// A simple pool that stores socket addresses and, for now, clones them out.
 ///
 /// Inspired by https://github.com/NicolasLM/nucleon/blob/master/src/backend.rs
+// TODO can probably get rid of the Rc<RefCell<_>> part
 #[derive(Clone, Debug, Default)]
 pub struct Pool {
     inner: Rc<RefCell<InnerPool>>,
@@ -28,19 +29,18 @@ impl Pool {
     {
         match self.inner.borrow_mut().get() {
             Some(backend) => {
-                let backend1 = backend.clone();
-                Box::new(f(&backend.borrow().server).then(move |res| {
+                Box::new(f(&backend.server()).then(move |res| {
                     match res {
                         Ok(res) => {
                             if res.status().is_server_error() {
-                                backend1.borrow_mut().stats_mut().inc_failure();
+                                backend.inc_failure();
                             } else {
-                                backend1.borrow_mut().stats_mut().inc_success();
+                                backend.inc_success();
                             }
                             ::futures::finished(res)
                         }
                         Err(e) => {
-                            backend1.borrow_mut().stats_mut().inc_failure();
+                            backend.inc_failure();
                             ::futures::failed(e)
                         }
                     }
@@ -54,9 +54,9 @@ impl Pool {
         }
     }
 
-    /// Returns all `Server` from the pool
-    pub fn all(&self) -> Vec<Server> {
-        self.inner.borrow_mut().all()
+    /// Returns all `Backend` from the pool
+    pub fn all(&self) -> Vec<Backend> {
+        self.inner.borrow().all()
     }
 
     /// Add a new server to the pool
@@ -69,20 +69,37 @@ impl Pool {
 
     /// Remove a server in the pool
     ///
-    pub fn remove(&self, backend: &Server) {
-        self.inner.borrow_mut().remove(backend)
+    pub fn remove(&self, server: &Server) {
+        self.inner.borrow_mut().remove(server)
+    }
+
+    pub fn find(&self, server: &Server) -> Option<Backend> {
+        self.inner.borrow().find(server)
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 enum ServerState {
     Active,
-    //Down,
+    Down,
     //Disabled,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Backend {
+    inner: Rc<RefCell<InnerBackend>>,
+}
+
+use std::hash::{Hash, Hasher};
+
+impl Hash for Backend {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.borrow().hash(state);
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+struct InnerBackend {
     server: Server,
     state: ServerState,
     stats: Stats,
@@ -91,20 +108,46 @@ pub struct Backend {
 impl Backend {
     pub fn new(server: Server) -> Backend {
         Backend {
-            server: server,
-            state: ServerState::Active,
-            stats: Stats::new(),
+            inner: Rc::new(RefCell::new(InnerBackend {
+                server: server,
+                state: ServerState::Active,
+                stats: Stats::new(),
+            }))
         }
     }
 
-    pub fn stats_mut(&mut self) -> &mut Stats {
-        &mut self.stats
+    pub fn inc_success(&self) {
+        self.inner.borrow_mut().stats.inc_success()
+    }
+
+    pub fn inc_failure(&self) {
+        self.inner.borrow_mut().stats.inc_failure()
+    }
+
+    pub fn server(&self) -> Server {
+        self.inner.borrow().server.clone()
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.inner.borrow().state == ServerState::Active
+    }
+
+    pub fn is_down(&self) -> bool {
+        self.inner.borrow().state == ServerState::Down
+    }
+
+    pub fn mark_active(&self) {
+        self.inner.borrow_mut().state = ServerState::Active;
+    }
+
+    pub fn mark_down(&self) {
+        self.inner.borrow_mut().state = ServerState::Down;
     }
 }
 
 #[derive(Debug, Default)]
 pub struct InnerPool {
-    backends: Vec<Rc<RefCell<Backend>>>,
+    backends: Vec<Backend>,
     last_used: usize,
 }
 
@@ -114,37 +157,50 @@ impl InnerPool {
     #[cfg(test)]
     fn new(backends: Vec<Backend>) -> InnerPool {
         InnerPool {
-            backends: backends.into_iter().map(|b| Rc::new(RefCell::new(b))).collect(),
+            backends: backends.into_iter().map(|b| b).collect(),
             last_used: 0,
         }
     }
 
-    fn get(&mut self) -> Option<Rc<RefCell<Backend>>> {
+    fn get(&mut self) -> Option<Backend> {
         if self.backends.is_empty() {
-            warn!("Pool is exhausted of socket addresses");
+            warn!("Pool is empty of backends");
             return None;
         }
-        self.last_used = (self.last_used + 1) % self.backends.len();
-        self.backends.get(self.last_used).map(|backend| {
+
+        let start = self.last_used;
+        loop {
+            self.last_used = (self.last_used + 1) % self.backends.len();
+            let backend = match self.backends.get(self.last_used) {
+                Some(b) => b,
+                None => return None,
+            };
+
+            if backend.is_down() {
+                if start == self.last_used {
+                    warn!("Pool has no active backends");
+                    return None;
+                }
+                continue;
+            }
+
             debug!("Pool is cloaning (hehe) out {:?}", backend);
-            // TODO make this Rc ?
-            backend.clone()
-        })
+            return Some(backend.clone());
+        }
     }
 
-    fn all(&mut self) -> Vec<Server> {
-        if self.backends.is_empty() {
-            warn!("Pool is exhausted of socket addresses");
-            return Vec::new();
-        }
+    fn all(&self) -> Vec<Backend> {
+        //if self.backends.is_empty() {
+        //    warn!("Pool is exhausted of backends");
+        //    return Vec::new();
+        //}
 
-        // TODO fix this to not need to clone the server. We can probably just pass the
-        // entire backend to the mgmt API and use the server value as a reference.
-        self.backends.iter().map(|backend| backend.borrow().server.clone()).collect()
+        //self.backends.iter().map(|backend| backend.clone()).collect()
+        self.backends.clone()
     }
 
     fn add(&mut self, backend: Backend) -> bool {
-        let backend = Rc::new(RefCell::new(backend));
+        let backend = backend;
         if self.backends.contains(&backend) {
             return false;
         }
@@ -154,7 +210,18 @@ impl InnerPool {
     }
 
     fn remove(&mut self, server: &Server) {
-        self.backends.retain(|b| &b.borrow().server != server);
+        self.backends.retain(|b| &b.server() != server);
+    }
+
+    fn find(&self, server: &Server) -> Option<Backend> {
+        match self.backends.iter().find(|b| &b.server() == server) {
+            Some(backend) => {
+                Some(backend.clone())
+            }
+            None => {
+                None
+            }
+        }
     }
 }
 
@@ -197,9 +264,11 @@ mod tests {
         let mut rrb = InnerPool::new(vec![]);
         assert!(rrb.get().is_none());
         let server = Server::new(FromStr::from_str("http://127.0.0.1:6000").unwrap(), false);
-        rrb.add(Backend::new(server.clone()));
+        let backend = Backend::new(server.clone());
+        rrb.add(backend);
+        let b1 = Backend::new(server.clone());
         assert!(rrb.get().is_some());
-        assert_eq!(vec![server], rrb.all());
+        assert_eq!(vec![b1], rrb.all());
     }
 
     #[test]
@@ -210,16 +279,18 @@ mod tests {
         rrb.add(Backend::new(server1.clone()));
         rrb.add(Backend::new(server2.clone()));
         assert_eq!(2, rrb.backends.len());
-        assert_eq!(vec![server1.clone(), server2.clone()], rrb.all());
+        let b1 = Backend::new(server1.clone());
+        let b2 = Backend::new(server2.clone());
+        assert_eq!(vec![b1.clone(), b2.clone()], rrb.all());
 
         let unknown_server = Server::new(FromStr::from_str("http://127.0.0.1:1234").unwrap(), false);
         rrb.remove(&unknown_server);
         assert_eq!(2, rrb.backends.len());
-        assert_eq!(vec![server1.clone(), server2.clone()], rrb.all());
+        assert_eq!(vec![b1.clone(), b2.clone()], rrb.all());
 
         rrb.remove(&server1);
         assert_eq!(1, rrb.backends.len());
-        assert_eq!(vec![server2.clone()], rrb.all());
+        assert_eq!(vec![b2.clone()], rrb.all());
 
         rrb.remove(&server2);
         assert_eq!(0, rrb.backends.len());

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,6 @@
 use hyper::Uri;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Server {
     url: Uri,
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Stats {
     failure: usize,
     success: usize,

--- a/weldr.capnp
+++ b/weldr.capnp
@@ -11,14 +11,12 @@ interface Publisher(T) {
 }
 
 interface Subscriber(T) {
-    pushMessage @0 (message: T) -> ();
-    # Sends a message from a publisher to the subscriber. To help with flow control, the subscriber should not
-    # return from this method until it is ready to process the next message.
-}
+    addServer @0 (url: Text) -> ();
+    # A request from the manager to the workers to add a new backend server to the pool
 
-struct AddBackendServerRequest {
-  # A request from the manager to the workers to add a new backend server to the pool
+    markServerDown @1 (url: Text) -> ();
+    # A request from the manager to the workers mark a server as down
 
-   url @0 :Text;
-   # The url of the new server to add to the pool
+    markServerActive @2 (url: Text) -> ();
+    # A request from the manager to the workers mark a server as down
 }


### PR DESCRIPTION
Fixes #17

- when manager changes a server's state (active/down) it will send
  messages to all workers
- added configurable success and failure thresholds for health
  checks