### PR TITLE
Make some changes to docker release process

### DIFF
--- a/travis_scripts/release.sh
+++ b/travis_scripts/release.sh
@@ -3,16 +3,16 @@
 function main {
     if [ ! -z $1 ]; then
       mkdir -p opt;
-      cp target/x86_64-unknown-linux-musl/release/weldr opt/;
       # Use the same docker image as much as possible
       docker run -v $PWD:/volume -w /volume -t clux/muslrust /volume/build.sh;
+      cp target/x86_64-unknown-linux-musl/release/weldr opt/;
       docker run -v $(pwd):/src/ cdrx/fpm-centos:7 -s dir -t deb -v $1 -n weldr -C /src  opt/weldr;
       docker run -v $(pwd):/src/ cdrx/fpm-centos:7 -s dir -t rpm -v $1 -n weldr -C /src  opt/weldr;
 
       # Publish to docker hub
       docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD;
-      docker build -t weldr/weldr:x86_64 .
-      docker push weldr/weldr:x86_64;
+      docker build -t weldr/weldr:$1 .
+      docker push weldr/weldr:$1;
     fi
 }
 


### PR DESCRIPTION
- build the static binary before trying to move it into `opt/`
- tag the container with the release tag